### PR TITLE
Ddls3 search table fix

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -601,6 +601,10 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		} else if (isDDLS3) {
 			BattleTeambuilderTable['ddls3patch'] = {};
 			BattleTeambuilderTable['ddls3patch'].learnsets = {};
+			BattleTeambuilderTable['ddls3patch'].tiers = tiers;
+			BattleTeambuilderTable['ddls3patch'].items = items;
+			BattleTeambuilderTable['ddls3patch'].overrideTier = overrideTier;
+			BattleTeambuilderTable['ddls3patch'].formatSlices = formatSlices;
 		} else if (isBW1 || isRS || isFRLG) {
 			BattleTeambuilderTable[gen] = {};
 			BattleTeambuilderTable[gen].overrideTier = overrideTier;

--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -727,7 +727,7 @@ abstract class BattleTypedSearch<T extends SearchType> {
 			if (!format) format = 'ou' as ID;
 		}
 		//ddl
-		if (format.includes('ddls3')) {
+		if (format.includes('ddls3') || format.includes('deltadraftleagueseason3')) {
 			this.formatType = 'ddls3';
 			this.dex = Dex.mod('ddls3patch' as ID);
 		}

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -268,6 +268,9 @@ export const Dex = new class implements ModdedDex {
 		let dex = Dex.forGen(Dex.formatGen(format));
 
 		const formatid = toID(format).slice(4);
+		if (formatid === 'ddls3patch') {
+			dex = Dex.mod('ddls3patch' as ID);
+		}
 		if (dex.gen === 7 && formatid.includes('letsgo')) {
 			dex = Dex.mod('gen7letsgo' as ID);
 		}
@@ -973,7 +976,10 @@ export class ModdedDex {
 		this.modid = modid;
 		let gen = parseInt(modid.charAt(3), 10);
 		if (this.modid === 'champions') gen = 9;
-		if ((modid !== 'champions' && !modid.startsWith('gen')) || !gen) throw new Error("Unsupported modid");
+		if (this.modid === 'ddls3patch') gen = 9; // Required to not throw err.
+		if (((modid !== 'champions' && modid !== 'ddls3patch') && !modid.startsWith('gen')) || !gen) {
+			throw new Error(`Unsupported modid ${modid}, ${gen}`);
+		}
 		this.gen = gen;
 	}
 	moves = {


### PR DESCRIPTION
Fixed the teambuilder not getting the ddls3patch table by adding it as an exception for Dex.mod and setting the formattype for typedseach using the correct format id. Furthermore, expanded the table data a bit more to match required data for the teambuilder.